### PR TITLE
Prevent Android context bar to appear when pressing the control button

### DIFF
--- a/style.css
+++ b/style.css
@@ -418,6 +418,7 @@ select#input13, select#pcwizard_option {
 	pointer-events: auto;
 	display: inline-block;
     touch-action: manipulation;
+	user-select: none;
     
 }
 
@@ -449,4 +450,5 @@ select#input13, select#pcwizard_option {
     width: 100%;
     padding: 8px;
     border: 1px solid #dddddd
+
   }


### PR DESCRIPTION
This is because it selects the text button, setting user-select: none prevents that behavior